### PR TITLE
Issue #22022: Updating the link colors for static and hover in light mode

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -77,6 +77,17 @@ a {
     }
 }
 
+a {
+    color: hsl(200, 90%, 40%);
+    text-decoration: none;
+}
+
+a:hover,
+a:focus {
+    color: hsl(200, 100%, 47%);
+    text-decoration: underline;
+}
+
 code,
 pre {
     font-family: "Source Code Pro", monospace;


### PR DESCRIPTION
This merge updates the link colors in static and hovered mode in Zulip message bodies and other similar links in light mode

Below is the comparison of before the change and after, with HTML inspection. 

**Prior to Change**
![image (1)](https://user-images.githubusercontent.com/98231876/207432341-2985110f-6303-4423-999a-bad95300b2f6.png)

**Post Change**
![image](https://user-images.githubusercontent.com/98231876/207429079-7e0cd650-3d20-422a-9337-14898db93355.png)
