### PR TITLE
Issue #22022: Updating the link colors for static and hover in light mode

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -77,6 +77,17 @@ a {
     }
 }
 
+a {
+    color: hsl(200, 90%, 40%);
+    text-decoration: none;
+}
+
+a:hover,
+a:focus {
+    color: hsl(200, 100%, 47%);
+    text-decoration: underline;
+}
+
 code,
 pre {
     font-family: "Source Code Pro", monospace;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -70,16 +70,13 @@ blockquote p {
 
 a {
     cursor: pointer;
+    color: hsl(200, 90%, 40%);
+    text-decoration: none;
 
     &.message_label_clickable:hover {
         cursor: pointer;
         color: hsl(200, 100%, 40%);
     }
-}
-
-a {
-    color: hsl(200, 90%, 40%);
-    text-decoration: none;
 }
 
 a:hover,


### PR DESCRIPTION
This merge updates the link colors in static and hovered mode in Zulip message bodies and other similar links in light mode

Below is the comparison of before the change and after, with HTML inspection.

**Prior to Change**
![image (1)](https://user-images.githubusercontent.com/98231876/207435379-a8976a3c-f8cd-4647-8d9c-7190cffb8207.png)


**Post Change**
![image](https://user-images.githubusercontent.com/98231876/207435372-a58eb6c6-fca5-4507-9d62-4a055d92c703.png)
